### PR TITLE
fix db.GetDB

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -10,10 +10,10 @@ import (
 
 var db *sql.DB
 
-func getDB() *sql.DB {
+func GetDB() *sql.DB {
 	if db == nil {
 		var err error
-		db, err := sql.Open("postgres" /*dataSourceName*/, "host=ec2-23-23-211-21.compute-1.amazonaws.com database=ddrkheg4gaufom user=yxdgjzsqajkoia password=pJoowuHjfQ_02pzTtbBieQq801")
+		db, err = sql.Open("postgres" /*dataSourceName*/, "host=ec2-23-23-211-21.compute-1.amazonaws.com database=ddrkheg4gaufom user=yxdgjzsqajkoia password=pJoowuHjfQ_02pzTtbBieQq801")
 		if err != nil {
 			panic(err)
 		}

--- a/todo.go
+++ b/todo.go
@@ -9,7 +9,7 @@ type Todo struct {
 }
 
 func GetAll() []Todo {
-	db := db.GetDb()
+	db := db.GetDB()
 	rows, err := db.Query("SELECT * FROM")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**Changes:**
-  `getDB` vs `GetDB` - getDB is not accessible from outside of `db` package / GetDB - func is accesible from outside
- `db, err := sql....` vs `db, err = sql...` My understanding that first one cratetes new local variables `db` and `err`. But you want to use `db` variable that is declared on line 11 and `err` from line 15, so you have to use `=`
